### PR TITLE
Fixing usage of ObjectOutputStream

### DIFF
--- a/src/spade/utility/BerkeleyDB.java
+++ b/src/spade/utility/BerkeleyDB.java
@@ -89,6 +89,7 @@ public class BerkeleyDB<V extends Serializable> implements ExternalStore<V> {
 		ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
 		ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteOutputStream);
 		objectOutputStream.writeObject(value);
+		objectOutputStream.flush();
 		byte[] valueBytes = byteOutputStream.toByteArray(); 
 		
 		DatabaseEntry keyEntry = new DatabaseEntry(key.getBytes());


### PR DESCRIPTION
When an `ObjectOutputStream` instance wraps an underlying `ByteArrayOutputStream` instance,
it is recommended to flush or close the `ObjectOutputStream` before invoking the underlying instances's `toByteArray()`. Although in this case, this is not strictly necessary because the `writeObject` method is invoked right before `toByteArray`, and `writeObject` internally calls flush/drain. However, it is a good practice to call flush/close explicitly as mentioned for example [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).

This pull request adds a flush method before calling `toByteArray()`.
