### PR TITLE
End of stream should exit `CommandLine.java`.

### DIFF
--- a/src/spade/client/CommandLine.java
+++ b/src/spade/client/CommandLine.java
@@ -210,7 +210,11 @@ public class CommandLine{
 						System.out.print(COMMAND_PROMPT);
 						line = commandReader.readLine();
 					}
-					
+
+					// If end of stream then set the command to exit
+					if(line == null){ // End of input
+						line = "exit";
+					}
 					if(StringUtils.isBlank(line)){
 						continue;
 					}


### PR DESCRIPTION
Piping commands to `spade query` required an explicit `quit` command to avoid getting stuck in a loop repeatedly printing the prompt. I copied over something similar to the code that was already in `src/spade/client/Control.java` to handle the end of stream case.