### PR TITLE
Fix and update postgres install script for Fedora

### DIFF
--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -2,7 +2,7 @@
 
 # Stop script on error. Otherwise the script continues and echos success
 # messages, even if not successful.
-set -ex
+set -e
 
 case $- in
 *i*)    # interactive shell
@@ -39,15 +39,18 @@ then
   makeUserDB(){
     local createCMD="CREATE ROLE ${vars[databaseUsername]} SUPERUSER LOGIN PASSWORD '${vars[databasePassword]}';"
     local skipIfExists="EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;"
+    # psql tries to change directory to current working dir, which user
+    # postgres doesn't always have permission to do.
+    pushd $TMPDIR/
     sudo -u postgres psql -c "DO \$\$
     BEGIN
     $createCMD
     $skipIfExists
     END
     \$\$;"
+    popd
     echo "*:*:*:${vars[databaseUsername]}:${vars[databasePassword]}" > $HOME/.pgpass
     echo "Successfully created superuser '${vars[databaseUsername]}'"
-    sudo sed -i -e '1ilocal   all  '"${vars[databaseUsername]}"'   trust\'  /etc/postgresql/9.5/main/pg_hba.conf
   }
   if [ "$DIST_NAME" = "Ubuntu" ]
   then
@@ -59,10 +62,12 @@ then
     sudo apt-get "$CONFIRM_INSTALL" install postgresql-9.5
     echo "Installed PostgreSQL 9.5"
     makeUserDB
+    sudo sed -i -e '1ilocal   all  '"${vars[databaseUsername]}"'   trust\'  /etc/postgresql/9.5/main/pg_hba.conf
     sudo service postgresql restart
     sudo  createdb ${vars[database]}  --owner=${vars[databaseUsername]} --username=${vars[databaseUsername]}
     echo "Successfully created database '${vars[database]}' for user '${vars[databaseUsername]}'"
   else
+    # Sets VERSION_ID to fedora version major num.
     eval "$(cat /etc/os-release  | grep VERSION_ID)"
     sudo dnf install "$CONFIRM_INSTALL" https://download.postgresql.org/pub/repos/yum/9.5/fedora/fedora-${VERSION_ID}-x86_64/pgdg-fedora-repo-latest.noarch.rpm
     sudo dnf install "$CONFIRM_INSTALL" postgresql95 postgresql95-server
@@ -73,6 +78,7 @@ then
     sudo systemctl enable postgresql-9.5
     sudo systemctl start postgresql-9.5
     makeUserDB
+    sudo sed -i -e '1ilocal   all  '"${vars[databaseUsername]}"'   trust\'  /var/lib/pgsql/9.5/data/pg_hba.conf
     sudo systemctl restart postgresql-9.5
     sudo createdb ${vars[database]} --owner=${vars[databaseUsername]} --username=${vars[databaseUsername]}
     echo "Successfully created database '${vars[database]}' for user '${vars[databaseUsername]}'"

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Fail on error. Otherwise the script continues and echos success messages,
+# even if not successful.
+set -e
+
 case $- in
 *i*)    # interactive shell
 ;;

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -2,7 +2,7 @@
 
 # Stop script on error. Otherwise the script continues and echos success
 # messages, even if not successful.
-set -e
+set -ex
 
 case $- in
 *i*)    # interactive shell
@@ -58,7 +58,9 @@ then
     sudo dnf install "$CONFIRM_INSTALL" https://download.postgresql.org/pub/repos/yum/9.5/fedora/fedora-${VERSION_ID}-x86_64/pgdg-fedora-repo-latest.noarch.rpm
     sudo dnf install "$CONFIRM_INSTALL" postgresql95 postgresql95-server
     echo "Installed PostgreSQL 9.5"
-    sudo /usr/pgsql-9.5/bin/postgresql95-setup initdb
+    if sudo [ ! -d "/var/lib/pgsql/9.5/data" ]; then
+      sudo /usr/pgsql-9.5/bin/postgresql95-setup initdb
+    fi
     sudo systemctl enable postgresql-9.5
     sudo systemctl start postgresql-9.5
     sudo -u postgres psql -c "CREATE ROLE ${vars[databaseUsername]} SUPERUSER LOGIN PASSWORD '${vars[databasePassword]}';"

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -65,8 +65,6 @@ then
     makeUserDB
     sudo sed -i -e '1ilocal   all  '"${vars[databaseUsername]}"'   trust\'  /etc/postgresql/9.5/main/pg_hba.conf
     sudo service postgresql restart
-    sudo  createdb ${vars[database]}  --owner=${vars[databaseUsername]} --username=${vars[databaseUsername]}
-    echo "Successfully created database '${vars[database]}' for user '${vars[databaseUsername]}'"
   else
     # Sets VERSION_ID to fedora version major num.
     eval "$(cat /etc/os-release  | grep VERSION_ID)"
@@ -87,9 +85,9 @@ then
     makeUserDB
     sudo sed -i -e '1ilocal   all  '"${vars[databaseUsername]}"'   trust\'  /var/lib/pgsql/9.5/data/pg_hba.conf
     sudo systemctl restart postgresql-9.5
-    sudo createdb ${vars[database]} --owner=${vars[databaseUsername]} --username=${vars[databaseUsername]}
-    echo "Successfully created database '${vars[database]}' for user '${vars[databaseUsername]}'"
   fi
+  sudo createdb ${vars[database]} --owner=${vars[databaseUsername]} --username=${vars[databaseUsername]}
+  echo "Successfully created database '${vars[database]}' for user '${vars[databaseUsername]}'"
 elif [ "$OS_NAME" = "Darwin" ]
 then
   brew install "$CONFIRM_INSTALL" postgresql@9.5

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -72,8 +72,14 @@ then
     sudo dnf install "$CONFIRM_INSTALL" https://download.postgresql.org/pub/repos/yum/9.5/fedora/fedora-${VERSION_ID}-x86_64/pgdg-fedora-repo-latest.noarch.rpm
     sudo dnf install "$CONFIRM_INSTALL" postgresql95 postgresql95-server
     echo "Installed PostgreSQL 9.5"
-    if sudo [ ! -d "/var/lib/pgsql/9.5/data" ]; then
+    # If the data directory already exists, initdb returns an error code.
+    # This would halt the script, so we check if it has already been created.
+    pg_data_dir="/var/lib/pgsql/9.5/data"
+    if sudo [ ! -d "$pg_data_dir" ]; then
+      echo "PostgreSQL data directory '$pg_data_dir' does not exist. Initialising default db..."
       sudo /usr/pgsql-9.5/bin/postgresql95-setup initdb
+    else
+      echo "PostgreSQL data directory '$pg_data_dir' already exists. Skipped default db initialisation"
     fi
     sudo systemctl enable postgresql-9.5
     sudo systemctl start postgresql-9.5

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+case $- in
+*i*)    # interactive shell
+;;
+*)      # non-interactive shell
+  CONFIRM_INSTALL="-y"
+;;
+
 declare -A vars=( )                  # refresh variables for each line
 while read  words; do                # iterate over lines of input
   set -- "${words[@]}"                 # update positional parameters
@@ -25,11 +32,11 @@ then
   if [ "$DIST_NAME" = "Ubuntu" ]
   then
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-    sudo apt-get install wget ca-certificates
+    sudo apt-get "$CONFIRM_INSTALL" install wget ca-certificates
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
     sudo apt-get update
     sudo apt-get upgrade
-    sudo apt-get install postgresql-9.5
+    sudo apt-get "$CONFIRM_INSTALL" install postgresql-9.5
     echo "Installed PostgreSQL 9.5"
     sudo -u postgres psql -c "CREATE ROLE ${vars[databaseUsername]} SUPERUSER LOGIN PASSWORD '${vars[databasePassword]}';"
     echo "*:*:*:${vars[databaseUsername]}:${vars[databasePassword]}" > $HOME/.pgpass
@@ -41,8 +48,8 @@ then
     echo "Successfully created database '${vars[database]}' for user '${vars[databaseUsername]}'"
   else
     eval "$(cat /etc/os-release  | grep VERSION_ID)"
-    sudo dnf install https://download.postgresql.org/pub/repos/yum/9.5/fedora/fedora-${VERSION_ID}-x86_64/pgdg-fedora-repo-latest.noarch.rpm
-    sudo dnf install postgresql95 postgresql95-server
+    sudo dnf install "$CONFIRM_INSTALL" https://download.postgresql.org/pub/repos/yum/9.5/fedora/fedora-${VERSION_ID}-x86_64/pgdg-fedora-repo-latest.noarch.rpm
+    sudo dnf install "$CONFIRM_INSTALL" postgresql95 postgresql95-server
     echo "Installed PostgreSQL 9.5"
     sudo /usr/pgsql-9.5/bin/postgresql95-setup initdb
     sudo systemctl enable postgresql-9.5
@@ -59,7 +66,7 @@ then
   fi
 elif [ "$OS_NAME" = "Darwin" ]
 then
-  brew install postgresql@9.5
+  brew install "$CONFIRM_INSTALL" postgresql@9.5
   pg_ctl -D /usr/local/var/postgres start && brew services start postgresql
   createuser ${vars[databaseUser]} --createdb --no-password
   echo "*:*:*:${vars[databaseUser]}:${vars[databasePassword]}" > $HOME/.pgpass

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -83,6 +83,8 @@ then
     sudo systemctl enable postgresql-9.5
     sudo systemctl start postgresql-9.5
     makeUserDB
+    # Added to the start of the file, so end up in reverse order.
+    sudo sed -i -e '1ihost   all  '"${vars[databaseUsername]}"'   localhost   trust\'  /var/lib/pgsql/9.5/data/pg_hba.conf
     sudo sed -i -e '1ilocal   all  '"${vars[databaseUsername]}"'   trust\'  /var/lib/pgsql/9.5/data/pg_hba.conf
     sudo systemctl restart postgresql-9.5
   fi

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -36,6 +36,14 @@ then
   if command -v lsb_release >/dev/null 2>&1; then
     DIST_NAME=$(lsb_release -is)
   fi
+  makeUserDB(){
+    # local skipExists="EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;"
+    local createCMD="BEGIN CREATE ROLE ${vars[databaseUsername]} SUPERUSER LOGIN PASSWORD '${vars[databasePassword]}';"
+    sudo -u postgres psql -c "$createCMD $skipExists"
+    echo "*:*:*:${vars[databaseUsername]}:${vars[databasePassword]}" > $HOME/.pgpass
+    echo "Successfully created superuser '${vars[databaseUsername]}'"
+    sudo sed -i -e '1ilocal   all  '"${vars[databaseUsername]}"'   trust\'  /etc/postgresql/9.5/main/pg_hba.conf
+  }
   if [ "$DIST_NAME" = "Ubuntu" ]
   then
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
@@ -45,11 +53,7 @@ then
     sudo apt-get upgrade
     sudo apt-get "$CONFIRM_INSTALL" install postgresql-9.5
     echo "Installed PostgreSQL 9.5"
-    sudo -u postgres psql -c "CREATE ROLE ${vars[databaseUsername]} SUPERUSER LOGIN PASSWORD '${vars[databasePassword]}';"
-    echo "*:*:*:${vars[databaseUsername]}:${vars[databasePassword]}" > $HOME/.pgpass
-    chmod 0600 $HOME/.pgpass
-    echo "Successfully created superuser '${vars[databaseUsername]}'"
-    sudo sed -i -e '1ilocal   all  '"${vars[databaseUsername]}"'   trust\'  /etc/postgresql/9.5/main/pg_hba.conf
+    makeUserDB
     sudo service postgresql restart
     sudo  createdb ${vars[database]}  --owner=${vars[databaseUsername]} --username=${vars[databaseUsername]}
     echo "Successfully created database '${vars[database]}' for user '${vars[databaseUsername]}'"
@@ -63,12 +67,7 @@ then
     fi
     sudo systemctl enable postgresql-9.5
     sudo systemctl start postgresql-9.5
-    sudo -u postgres psql -c "CREATE ROLE ${vars[databaseUsername]} SUPERUSER LOGIN PASSWORD '${vars[databasePassword]}';"
-    #sudo -u postgres createuser ${vars[databaseUsername]} --superuser --no-password
-    echo "*:*:*:${vars[databaseUsername]}:${vars[databasePassword]}" > $HOME/.pgpass
-    chmod 0600 $HOME/.pgpass
-    echo "Successfully created superuser '${vars[databaseUsername]}'"
-    sudo sed -i -e '1ilocal   all  '"${vars[databaseUsername]}"'   trust\'  /etc/postgresql/9.5/main/pg_hba.conf
+    makeUserDB
     sudo systemctl restart postgresql-9.5
     sudo createdb ${vars[database]} --owner=${vars[databaseUsername]} --username=${vars[databaseUsername]}
     echo "Successfully created database '${vars[database]}' for user '${vars[databaseUsername]}'"

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Fail on error. Otherwise the script continues and echos success messages,
-# even if not successful.
+# Stop script on error. Otherwise the script continues and echos success
+# messages, even if not successful.
 set -e
 
 case $- in
@@ -10,6 +10,7 @@ case $- in
 *)      # non-interactive shell
   CONFIRM_INSTALL="-y"
 ;;
+esac
 
 declare -A vars=( )                  # refresh variables for each line
 while read  words; do                # iterate over lines of input
@@ -32,7 +33,9 @@ done <cfg/spade.storage.PostgreSQL.config
 OS_NAME=$(uname)
 if [ "$OS_NAME" = "Linux" ]
 then
-  DIST_NAME=$(lsb_release -is)
+  if command -v lsb_release >/dev/null 2>&1; then
+    DIST_NAME=$(lsb_release -is)
+  fi
   if [ "$DIST_NAME" = "Ubuntu" ]
   then
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -19,10 +19,10 @@ done <cfg/spade.storage.PostgreSQL.config
 # PostgreSQL installation
 
 OS_NAME=$(uname)
-if [ $OS_NAME == "Linux" ]
+if [ "$OS_NAME" = "Linux" ]
 then
   DIST_NAME=$(lsb_release -is)
-  if [ $DIST_NAME == "Ubuntu" ]
+  if [ "$DIST_NAME" = "Ubuntu" ]
   then
     sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
     sudo apt-get install wget ca-certificates
@@ -57,7 +57,7 @@ then
     sudo createdb ${vars[database]} --owner=${vars[databaseUsername]} --username=${vars[databaseUsername]}
     echo "Successfully created database '${vars[database]}' for user '${vars[databaseUsername]}'"
   fi
-elif [ $OS_NAME == "Darwin" ]
+elif [ "$OS_NAME" = "Darwin" ]
 then
   brew install postgresql@9.5
   pg_ctl -D /usr/local/var/postgres start && brew services start postgresql

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -40,7 +40,8 @@ then
     sudo  createdb ${vars[database]}  --owner=${vars[databaseUsername]} --username=${vars[databaseUsername]}
     echo "Successfully created database '${vars[database]}' for user '${vars[databaseUsername]}'"
   else
-    sudo dnf install https://download.postgresql.org/pub/repos/yum/9.5/fedora/fedora-28-x86_64/pgdg-fedora95-9.5-5.noarch.rpm
+    eval "$(cat /etc/os-release  | grep VERSION_ID)"
+    sudo dnf install https://download.postgresql.org/pub/repos/yum/9.5/fedora/fedora-${VERSION_ID}-x86_64/pgdg-fedora-repo-latest.noarch.rpm
     sudo dnf install postgresql95 postgresql95-server
     echo "Installed PostgreSQL 9.5"
     sudo /usr/pgsql-9.5/bin/postgresql95-setup initdb

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -37,9 +37,14 @@ then
     DIST_NAME=$(lsb_release -is)
   fi
   makeUserDB(){
-    # local skipExists="EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;"
-    local createCMD="BEGIN CREATE ROLE ${vars[databaseUsername]} SUPERUSER LOGIN PASSWORD '${vars[databasePassword]}';"
-    sudo -u postgres psql -c "$createCMD $skipExists"
+    local createCMD="CREATE ROLE ${vars[databaseUsername]} SUPERUSER LOGIN PASSWORD '${vars[databasePassword]}';"
+    local skipIfExists="EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;"
+    sudo -u postgres psql -c "DO \$\$
+    BEGIN
+    $createCMD
+    $skipIfExists
+    END
+    \$\$;"
     echo "*:*:*:${vars[databaseUsername]}:${vars[databasePassword]}" > $HOME/.pgpass
     echo "Successfully created superuser '${vars[databaseUsername]}'"
     sudo sed -i -e '1ilocal   all  '"${vars[databaseUsername]}"'   trust\'  /etc/postgresql/9.5/main/pg_hba.conf

--- a/bin/installPostgres
+++ b/bin/installPostgres
@@ -50,6 +50,7 @@ then
     \$\$;"
     popd
     echo "*:*:*:${vars[databaseUsername]}:${vars[databasePassword]}" > $HOME/.pgpass
+    chmod 0600 $HOME/.pgpass
     echo "Successfully created superuser '${vars[databaseUsername]}'"
   }
   if [ "$DIST_NAME" = "Ubuntu" ]


### PR DESCRIPTION
* Set to always get the install link for the current Fedora version, instead of assuming a version.
* Halt script on error, instead of failing but telling user the script was successful
* Fix several fragile bits that caused errors that would now halt the script.
* Fix some paths that are different under Fedora (at least 31.
