### PR TITLE
5.7 kernel modules kallsyms

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -155,11 +155,12 @@ audit-kernel-module:
 				exit 1; \
 			else \
 				if [ $(OS_KERNEL_NUMBER) -ge $(MAX_OS_KERNEL_NUMBER) ]; then \
-					echo 'ERROR: Kernel modules not supported for kernel versions 5.7 and higher. Use command "make KERNEL_MODULES=false" to skip building kernel modules.'; \
-					exit 1; \
+					echo 'Kernel version > 5.7: might fail. Using hack from https://github.com/xcellerator/linux_kernel_hacking/issues/3#issue-782815541 by hkerma'; \
+					echo 'Better pray...'; \
 				else \
-					$(MAKE) --no-print-directory -f $(AUDIT_KERNEL_MODULES_MAKEFILE); \
-				fi \
+					echo 'Building kernel modules normally'; \
+				fi; \
+				$(MAKE) --no-print-directory -f $(AUDIT_KERNEL_MODULES_MAKEFILE); \
 			fi \
 		else \
 			$(MAKE) --no-print-directory -f $(AUDIT_KERNEL_MODULES_MAKEFILE) clean; \

--- a/src/spade/reporter/audit/kernel-modules/netio.c
+++ b/src/spade/reporter/audit/kernel-modules/netio.c
@@ -20,7 +20,7 @@
 
 #include <linux/audit.h>
 #include <linux/file.h>
-// #include <linux/kallsyms.h>
+#include <linux/kallsyms.h>
 #include <linux/mnt_namespace.h>
 #include <linux/pid_namespace.h>
 #include <linux/net_namespace.h>


### PR DESCRIPTION
Hello
Thanks for creating SPADE: it's great!
Few months, I had to use SPADE with namespace awareness (CLARION) on a recent kernel (>5.7). I realized it would not work because of the kernel modules (kallsyms is not exported anymore after 5.7).
I build a quick fix based on [this issue and proposed fix](https://github.com/xcellerator/linux_kernel_hacking/issues/3#issue-782815541). It plants a kprobe to manually get the kallsyms_lookup_function without the symbol.

I tried it on my side (Ubuntu 22.04 kernel 5.17) a few months back and it seems to compile/work when I used it (`add reporter Audit localEndpoints=true namespaces=true IPC=true networkAddressTranslation=true`)

Feel free to ignore if you think it's too hacky.

Best regards,
Hugo